### PR TITLE
bumped the react-native-make version

### DIFF
--- a/conferencing/package.json
+++ b/conferencing/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.14.3",
+    "@babel/plugin-proposal-class-properties": "^7.16.0",
     "@babel/preset-env": "7.14.4",
     "@babel/preset-react": "7.13.13",
     "@babel/preset-typescript": "7.13.0",

--- a/conferencing/package.json
+++ b/conferencing/package.json
@@ -66,7 +66,7 @@
     "@babel/preset-react": "7.13.13",
     "@babel/preset-typescript": "7.13.0",
     "@babel/runtime": "7.14.0",
-    "@bam.tech/react-native-make": "3.0.0",
+    "@bam.tech/react-native-make": "3.0.3",
     "@pmmmwh/react-refresh-webpack-plugin": "0.3.3",
     "@react-native-community/eslint-config": "1.1.0",
     "@types/jest": "25.2.3",


### PR DESCRIPTION
# Related Issue
- `npm i` was failing on node v16, because of the outdated version of lib sharp.
- Issue: https://app.clickup.com/t/1u52k1u

# Propossed changes/Fix
- @bam.tech/react-native-make 3.0.0 had dev-dependency of sharp v 0.23, which was causing the "npm i" to fail, the latest @bam.tech/react-native-make version 3.0.3 address this issue and have updated their dev-dependency of sharp to v0.28. Hence updating the version of @bam.tech/react-native-make to 3.0.3 in conferencing package.json, fixes the issue and 'npm i' runs successfully without any sharp lib issue.

# Additional Info 
- Error log attached in ticket  https://app.clickup.com/t/1u52k1u

# Checklist
- [x] Tested on local/dev branch for all major platforms (Android, IOS, Desktop, Web).
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- Mention dependent PR links.


# Screenshots

Original              
:---------------------:  
<img width="1346" alt="install-error-rc-make-3 0 0" src="https://user-images.githubusercontent.com/22396308/140871458-a898dbdd-9069-4c52-9488-66deae1da1ad.png">

Updated              
:---------------------:  
<img width="1347" alt="install-success-rc-make-3 0 3" src="https://user-images.githubusercontent.com/22396308/140871689-f031980b-fb73-484d-abc6-25e218a8e82b.png">


