### PR TITLE
Screen sharing loop fix

### DIFF
--- a/conferencing/src/components/GridVideo.tsx
+++ b/conferencing/src/components/GridVideo.tsx
@@ -96,7 +96,16 @@ const GridVideo = (props: GridVideoProps) => {
                 marginHorizontal: 'auto',
               }}
               key={cidx}>
-              <View style={style.gridVideoContainerInner}>
+              {
+                users[ridx * dims.c + cidx].uid === 1 
+                ?
+                  <View style={styles.screenSharingMessageContainer}>
+                      <Text style={styles.screensharingMessage}>
+                        Screen sharing is active now. 
+                      </Text>
+                  </View>
+                :
+                <View style={style.gridVideoContainerInner}>
                 <MaxVideoView
                   fallback={() => {
                     if (users[ridx * dims.c + cidx].uid === 'local') {
@@ -181,7 +190,7 @@ const GridVideo = (props: GridVideoProps) => {
                     users[ridx * dims.c + cidx].uid,
                   )} */}
                 </View>
-              </View>
+              </View>}
             </Pressable>
           ))}
         </View>

--- a/conferencing/src/components/GridVideo.tsx
+++ b/conferencing/src/components/GridVideo.tsx
@@ -29,6 +29,7 @@ import ColorContext from './ColorContext';
 import FallbackLogo from '../subComponents/FallbackLogo';
 import Layout from '../subComponents/LayoutEnum';
 import RtcContext, {DispatchType} from '../../agora-rn-uikit/src/RtcContext';
+import ScreenShareNotice from '../subComponents/ScreenShareNotice';
 
 const layout = (len: number, isDesktop: boolean = true) => {
   const rows = Math.round(Math.sqrt(len));
@@ -96,15 +97,7 @@ const GridVideo = (props: GridVideoProps) => {
                 marginHorizontal: 'auto',
               }}
               key={cidx}>
-              {
-                users[ridx * dims.c + cidx].uid === 1 
-                ?
-                  <View style={styles.screenSharingMessageContainer}>
-                      <Text style={styles.screensharingMessage}>
-                        Screen sharing is active now. 
-                      </Text>
-                  </View>
-                :
+                <ScreenShareNotice uid={users[ridx * dims.c + cidx].uid} />
                 <View style={style.gridVideoContainerInner}>
                 <MaxVideoView
                   fallback={() => {
@@ -190,7 +183,7 @@ const GridVideo = (props: GridVideoProps) => {
                     users[ridx * dims.c + cidx].uid,
                   )} */}
                 </View>
-              </View>}
+              </View>
             </Pressable>
           ))}
         </View>

--- a/conferencing/src/components/PinnedVideo.tsx
+++ b/conferencing/src/components/PinnedVideo.tsx
@@ -29,6 +29,7 @@ import icons from '../assets/icons';
 import {layoutProps} from '../../theme.json';
 import FallbackLogo from '../subComponents/FallbackLogo';
 import styles from './styles';
+import ScreenShareNotice from '../subComponents/ScreenShareNotice';
 
 const {topPinned} = layoutProps;
 
@@ -194,14 +195,8 @@ const PinnedVideo = () => {
         }>
         <MaxUidConsumer>
           {(maxUsers) => (
-            maxUsers[0].uid === 1 
-            ?
-              <View style={styles.screenSharingMessageContainer}>
-                <Text style={styles.screensharingMessage}>
-                  Screen sharing is active now. 
-                </Text>
-              </View>
-            :
+            <>
+            <ScreenShareNotice uid={maxUsers[0].uid} />
             <View style={style.flex1}>
               <MaxVideoView
                 fallback={() => {
@@ -244,6 +239,7 @@ const PinnedVideo = () => {
                 </Text>
               </View>
             </View>
+            </>
           )}
         </MaxUidConsumer>
       </View>

--- a/conferencing/src/components/PinnedVideo.tsx
+++ b/conferencing/src/components/PinnedVideo.tsx
@@ -28,6 +28,7 @@ import ColorContext from './ColorContext';
 import icons from '../assets/icons';
 import {layoutProps} from '../../theme.json';
 import FallbackLogo from '../subComponents/FallbackLogo';
+import styles from './styles';
 
 const {topPinned} = layoutProps;
 
@@ -47,7 +48,7 @@ const PinnedVideo = () => {
     }, 20);
   };
   const isSidePinnedlayout = topPinned === true ? false : dim[2]; // if either explicity set to false or auto evaluation
-  const {userList, localUid} = useContext(chatContext);
+  const {userList, localUid} = useContext(chatContext);  
   return (
     <View
       style={{
@@ -193,6 +194,14 @@ const PinnedVideo = () => {
         }>
         <MaxUidConsumer>
           {(maxUsers) => (
+            maxUsers[0].uid === 1 
+            ?
+              <View style={styles.screenSharingMessageContainer}>
+                <Text style={styles.screensharingMessage}>
+                  Screen sharing is active now. 
+                </Text>
+              </View>
+            :
             <View style={style.flex1}>
               <MaxVideoView
                 fallback={() => {

--- a/conferencing/src/components/styles.ts
+++ b/conferencing/src/components/styles.ts
@@ -9,10 +9,9 @@
  information visit https://appbuilder.agora.io. 
 *********************************************
 */
-import {Platform,StyleSheet} from 'react-native';
+import {Platform} from 'react-native';
 
-//Added stylesheet component for type checking and style validation
-const styles = StyleSheet.create({
+const styles = {
   temp: {
     width: '100%',
     height: '100%',
@@ -84,6 +83,6 @@ const styles = StyleSheet.create({
   screensharingMessage:{
     alignSelf:'center',fontSize: 20
   }
-});
+};
 
 export default styles;

--- a/conferencing/src/components/styles.ts
+++ b/conferencing/src/components/styles.ts
@@ -74,14 +74,6 @@ const styles = {
     position: 'absolute',
     right: 5,
     top: 5,
-  },
-  screenSharingMessageContainer:{
-    flex:1,
-    justifyContent:'center',
-    backgroundColor:'transparent'
-  },
-  screensharingMessage:{
-    alignSelf:'center',fontSize: 20
   }
 };
 

--- a/conferencing/src/components/styles.ts
+++ b/conferencing/src/components/styles.ts
@@ -9,9 +9,10 @@
  information visit https://appbuilder.agora.io. 
 *********************************************
 */
-import {Platform} from 'react-native';
+import {Platform,StyleSheet} from 'react-native';
 
-const styles = {
+//Added stylesheet component for type checking and style validation
+const styles = StyleSheet.create({
   temp: {
     width: '100%',
     height: '100%',
@@ -75,6 +76,14 @@ const styles = {
     right: 5,
     top: 5,
   },
-};
+  screenSharingMessageContainer:{
+    flex:1,
+    justifyContent:'center',
+    backgroundColor:'transparent'
+  },
+  screensharingMessage:{
+    alignSelf:'center',fontSize: 20
+  }
+});
 
 export default styles;

--- a/conferencing/src/subComponents/ScreenShareNotice.tsx
+++ b/conferencing/src/subComponents/ScreenShareNotice.tsx
@@ -1,0 +1,54 @@
+/*
+********************************************
+ Copyright © 2021 Agora Lab, Inc., all rights reserved.
+ AppBuilder and all associated components, source code, APIs, services, and documentation 
+ (the “Materials”) are owned by Agora Lab, Inc. and its licensors. The Materials may not be 
+ accessed, used, modified, or distributed for any purpose without a license from Agora Lab, Inc.  
+ Use without a license or in violation of any license terms and conditions (including use for 
+ any purpose competitive to Agora Lab, Inc.’s business) is strictly prohibited. For more 
+ information visit https://appbuilder.agora.io. 
+*********************************************
+*/
+
+import React from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+/**
+ *
+ * @param uid - uid of the user 
+ * @returns This component display overlay message "Screen sharing is active now" if user started sharing the screen.
+ * why its needed : To prevent screensharing tunneling effect 
+ * 
+ */
+function ScreenShareNotice({ uid }: any) {
+    return uid === 1
+        ?
+        <View style={styles.screenSharingMessageContainer}>
+            <Text style={styles.screensharingMessage}>
+                Screen sharing is active now.
+            </Text>
+        </View>
+        : null
+}
+
+const styles = StyleSheet.create({
+    screenSharingMessageContainer: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        width: '100%',
+        height: '100%',
+        justifyContent: 'center',
+        zIndex: 2,
+        backgroundColor: 'rgba(0,0,0,0.9)',
+        borderRadius: 15
+    },
+    screensharingMessage: {
+        alignSelf: 'center',
+        fontSize: 20,
+        color: $config.SECONDARY_FONT_COLOR
+    }
+})
+
+export default ScreenShareNotice;


### PR DESCRIPTION
# Related Issue
- Dimming the UI when sharing the screen
- [clickup ticket](https://app.clickup.com/t/e5chm5)

# Propossed changes/Fix
- Created screensharenotice component which will display the message
- Integrated that component in pinned/grid video files
- Checking uid 1 should solve this issue. uid 1 means local user sharing screen

# Additional Info 
- In a meeting a and b are there
- if a user sharing the screen - then that screenshare user uid is 1 for a’user end and its having xxx uid in another end
- if b user sharing the screen - then that screenshare user uid is 1 for b’user end and its having xxx uid in another end

# Checklist
- [x] Tested on local/dev branch for all major platforms (~~Android, IOS~~, Desktop, Web). (Not tested in Android, IOS since screen sharing feature is not available)
- [x] No commented out code
- [ ] Is any third party library, service used
- [ ] Tests
- [ ] If this change requires updates outside of the code, like updates in core, react-ui-kit, RTM/RTC configure.

# Dependent PRs 
- N/A


# Screenshots

**Original** 

_PinnedView_

<img width="1788" alt="issue-in-pinned-view" src="https://user-images.githubusercontent.com/13586565/142192312-3bc0c624-a105-4c50-8d5e-65179b89ee14.png">

_GridView_

<img width="1792" alt="issue-in-grid-view" src="https://user-images.githubusercontent.com/13586565/142192469-4ef139d9-dbdc-41cd-9b2f-722656e7a0fa.png">  

**Updated**

_PinnedView_

<img width="1786" alt="fixed-in-pinned-view" src="https://user-images.githubusercontent.com/13586565/142192402-9ebae193-db90-4733-ad4b-8ba6e5f1921e.png">

_GridView_

<img width="1786" alt="fixed-in-grid-view" src="https://user-images.githubusercontent.com/13586565/142192523-be2fddc7-9a37-4e26-8cdc-a982ba8610a9.png">
